### PR TITLE
Fix wrong start values and jumping effects in reactive computations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,3 +19,8 @@ This meteor package is a fork of [elevatedevdesign:autoform-nouislider](https://
 ### 0.5
 - Update nouislider to 14.0.2
 - Removed underscore dependency
+
+### 0.5.1
+- prevent potential jump effect on reactive computations in cases, where documents are edited (update form) and a new 
+slider value has been set
+- fix start value on the slider was set to 0 when editing a document with a given value

--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -122,10 +122,21 @@ Template.afNoUiSlider.rendered = function () {
   const template = this
   const $s = template.$('.nouislider')
 
+  let nonReactiveValue
+
   const setup = function (c) {
     const data = Template.currentData() // get data reactively
     const options = calculateOptions(data)
     const sliderElem = $s[ 0 ]
+
+    // if   we have a new computation and
+    //      we have a given value (for example by editing a saved document) and
+    //      we have already changed the value
+    // then we will use the changed value instead of the initial value
+    // to avoid a potential "jumping" effect when saving the form
+    if (typeof data.value !== 'undefined' && typeof nonReactiveValue !== 'undefined') {
+      options.start = nonReactiveValue
+    }
 
     if (sliderElem.noUiSlider) {
       sliderElem.noUiSlider.updateOptions(options, true)
@@ -140,7 +151,8 @@ Template.afNoUiSlider.rendered = function () {
         // emits a change event. Eventually AutoForm will give
         // input types the control of indicating exactly when
         // their value changes rather than relying on the change event
-        $s.parent()[ 0 ].value = JSON.stringify(sliderElem.noUiSlider.get())
+        nonReactiveValue = sliderElem.noUiSlider.get()
+        $s.parent()[ 0 ].value = JSON.stringify(nonReactiveValue)
         $s.parent().change()
         $s.data('changed', 'true')
       })

--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -81,7 +81,7 @@ const calculateOptions = function (data) {
   const options = merge(schemaMinMax, autoformOptions, noUiSliderOptions)
 
   // Adjust data initialization based on schema type
-  if (options.start === undefined) {
+  if (!options.start) {
     if (data.schemaType.name === 'Object') {
       if (data.value && data.value.lower) {
         options.start = [

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: 'muqube:autoform-nouislider',
   summary: 'Dual value slider for autoform.',
-  version: '0.5.0',
+  version: '0.5.1',
   git: 'https://github.com/muqube/meteor-autoform-nouislider'
 })
 


### PR DESCRIPTION
Reproduce with current `0.5.0`:

- create an update form with validation on submit and edit an existing document with a slider value
- use the schema with a  `start` value and with tracker
- update the document and save
- reload the page
- the initial value will be 0, although internally the value is set
- if the start value is not defined the value is set correct, however, when changing the value and saving the form it will "jump" in the validation phase to the initial value then jumping to the new value

This PR fixes both