### PR TITLE
feature: allow to import extension dynamically and statically

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ muqube:autoform-nouislider
 
 `meteor add muqube:autoform-nouislider`
 
+There are two ways to import the package: dynamic and static. 
+The default way is dynamic, where you import a function, containing a dynamic import.
+This prevents this package from being added to the initial client bundle and allows
+you to import it only at that point when it's really required.
+
+```js
+import loadAfNoUiSlider from 'meteor/muqube:autoform-nouislider'
+
+// This is only an example of how to reactively track
+// if the extension has been loaded.
+// You can, of course, track it anyway you want!
+Template.myTemplate.onCreated(async function () {
+  const instance = this
+  instance.state = new ReactiveDict()
+  await loadAfNoUiSlider.default()
+  instance.state.set('afNoUiSliderLoaded', true)
+})
+```
+
+If you really need this package being added to the initial bundle, thus being present at
+startup time, then you should use the static import:
+
+```javascript
+import 'meteor/muqube:autoform-nouislider/static'
+```
+
 ## Configuration
 Adds the `noUiSlider` type to [autoform](https://github.com/aldeed/meteor-autoform). It uses `min`, `max`, and `step` attributes like a normal slider, so it can be a drop in replacement, but options passed as `noUiSliderOptions` are passed directly to [nouislider](http://refreshless.com/nouislider/) for advanced control.
 

--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -1,7 +1,7 @@
 /* global AutoForm, Template */
-
 import noUiSlider from 'nouislider'
 import 'nouislider/distribute/nouislider.css'
+import './autoform-nouislider.css'
 import './autoform-nouislider.html'
 
 AutoForm.addInputType('noUiSlider', {

--- a/main.js
+++ b/main.js
@@ -1,0 +1,8 @@
+/**
+ * This is the main entry point for dynamically loading this extension.
+ * Use it to defer the loading to the point when it's really needed.
+ * @return {Promise<{}>}
+ */
+export default function () {
+  return import('./static')
+}

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: 'muqube:autoform-nouislider',
   summary: 'Dual value slider for autoform.',
-  version: '0.5.2',
+  version: '0.6.0',
   git: 'https://github.com/muqube/meteor-autoform-nouislider'
 })
 
@@ -17,9 +17,5 @@ Package.onUse(function (api) {
   api.use('templating@1.0.0')
   api.use('blaze@2.0.0')
   api.use('aldeed:autoform@4.0.0 || 5.0.0 || 6.0.0 || 7.0.0')
-  api.addFiles([
-    'autoform-nouislider.html',
-    'autoform-nouislider.js',
-    'autoform-nouislider.css'
-  ], 'client')
+  api.mainModule('main.js', 'client')
 })

--- a/static.js
+++ b/static.js
@@ -1,0 +1,1 @@
+import './autoform-nouislider'


### PR DESCRIPTION
This PR enables to either fully dynamically or fully statically import this package. This allows full code splitting and reduce initial bundle size.

Excerpt from README:

There are two ways to import the package: dynamic and static. 
The default way is dynamic, where you import a function, containing a dynamic import.
This prevents this package from being added to the initial client bundle and allows
you to import it only at that point when it's really required.

```js
import loadAfNoUiSlider from 'meteor/muqube:autoform-nouislider'
// This is only an example of how to reactively track
// if the extension has been loaded.
// You can, of course, track it anyway you want!
Template.myTemplate.onCreated(async function () {
  const instance = this
  instance.state = new ReactiveDict()
  await loadAfNoUiSlider.default()
  instance.state.set('afNoUiSliderLoaded', true)
})
```

If you really need this package being added to the initial bundle, thus being present at
startup time, then you should use the static import:

```javascript
import 'meteor/muqube:autoform-nouislider/static'
```

